### PR TITLE
Fix Node.js version requirement for Vite and Tailwind

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Problem

The frontend build fails on Node 18.20.5 because Vite 7.3.1, Tailwind CSS 4.2.0, React Router 7.13.0, and @vitejs/plugin-react 5.1.4 all require Node 20+. The build crashes with "Cannot find native binding" because @tailwindcss/oxide ships a native module compiled for Node 20+ that cannot be loaded on Node 18.

## Solution

Added an `engines` field to `frontend/package.json` specifying `"node": ">=20"`. Railpack reads this field to select the correct Node.js version for the build environment, ensuring native modules like @tailwindcss/oxide are compiled and loaded against a compatible runtime.

### Changes
- **Modified** `frontend/package.json`

---
*Generated by [Railway](https://railway.com)*