### PR TITLE
Exempt healthcheck from HTTPS enforcement

### DIFF
--- a/api/security.py
+++ b/api/security.py
@@ -121,6 +121,8 @@ def enforce_https_if_needed(request: Request) -> Optional[RedirectResponse]:
     enforce_https = env_bool("ENFORCE_HTTPS", os.environ.get("APP_ENV", "").lower() in {"production", "prod", "staging"})
     if not enforce_https:
         return None
+    if request.url.path == "/api/health":
+        return None
     if is_https_request(request):
         return None
     if should_allow_insecure_local_request(request):


### PR DESCRIPTION
## Problem

Railway's healthcheck probe sends plain HTTP requests to `/api/health` and expects a 2xx response, but `enforce_https_if_needed` in `api/security.py` was issuing a 307 redirect to HTTPS for all non-HTTPS traffic, causing the healthcheck to fail.

## Solution

Added an early-return guard in `enforce_https_if_needed` that skips HTTPS enforcement when the request path is `/api/health`. All other endpoints continue to be redirected to HTTPS as before.

### Changes
- **Modified** `api/security.py`

---
*Generated by [Railway](https://railway.com)*