### PR TITLE
Update Node.js version requirement to be more flexible

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=20.19"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Problem

The frontend build fails with "Vite requires Node.js version 20.19+ or 22.12+" because the build environment resolves to Node 22.11.0 — a version that falls in the gap between Vite's two supported ranges. The engines field was set to `>=20`, which is too broad and allows Railpack to select 22.11.0.

## Solution

Updated the engines field in `frontend/package.json` from `>=20` to `>=20.19`. This tighter constraint causes Railpack to select a Node version that satisfies Vite's minimum requirement (20.19+ or 22.12+), avoiding the incompatible 22.11.x range.

### Changes
- **Modified** `frontend/package.json`

---
*Generated by [Railway](https://railway.com)*