### PR TITLE
Bypass TrustedHostMiddleware for healthcheck endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -65,6 +65,20 @@ def create_app() -> FastAPI:
     allowed_hosts = parse_allowed_hosts()
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=allowed_hosts)
 
+    # Bypass TrustedHostMiddleware for the healthcheck endpoint so that
+    # Railway's internal probe (which sends no matching Host header) always
+    # gets a 200 rather than a 400.  This middleware is added *after*
+    # TrustedHostMiddleware so that Starlette wraps it on the outside and it
+    # therefore runs *first* in the request chain.
+    @app.middleware("http")
+    async def health_bypass_middleware(request: Request, call_next):
+        if request.url.path == "/api/health":
+            healthy = await db.health_check()
+            return JSONResponse(
+                content={"status": "ok" if healthy else "degraded", "database": healthy}
+            )
+        return await call_next(request)
+
     cors_origins_raw = os.environ.get("CORS_ALLOW_ORIGINS", "http://localhost:5173")
     cors_origins = [o.strip() for o in cors_origins_raw.split(",") if o.strip()]
     app.add_middleware(


### PR DESCRIPTION
## Problem

Railway's internal healthcheck probe sends requests from 100.64.0.2 with a Host header that doesn't match `ALLOWED_HOSTS`, causing `TrustedHostMiddleware` to reject every probe with a 400 Bad Request and the service to appear unhealthy.

## Solution

Added a `health_bypass_middleware` in `api/main.py` that is registered via `@app.middleware("http")` immediately after `TrustedHostMiddleware` is added. Because Starlette wraps middleware in reverse registration order, this middleware runs first in the chain and short-circuits `/api/health` requests directly — returning the DB health JSON response before the request ever reaches `TrustedHostMiddleware`. All other paths continue through the full middleware stack unchanged.

### Changes
- **Modified** `api/main.py`

---
*Generated by [Railway](https://railway.com)*