### PR TITLE
Add railpack.toml to skip tests during build

### DIFF
--- a/railpack.toml
+++ b/railpack.toml
@@ -1,0 +1,8 @@
+[phases.install]
+cmds = ["pip install -r requirements.txt"]
+
+[phases.test]
+skip = true
+
+[start]
+cmd = "uvicorn api.main:app --host 0.0.0.0 --port $PORT"


### PR DESCRIPTION
## Problem

Railpack auto-detects the pytest test suite and runs all 843 tests during the build phase, inflating build time from ~30 seconds to ~4 minutes. The old `nixpacks.toml` is no longer used by Railpack, so there was no configuration in place to suppress this behaviour.

## Solution

Added a `railpack.toml` at the repository root that explicitly sets `phases.test.skip = true`, preventing Railpack from running pytest during deployment builds. The install and start commands are carried over from the deprecated `nixpacks.toml` to keep the build fully defined. Tests can still be run locally or in a dedicated CI pipeline.

### Changes
- **Created** `railpack.toml`

---
*Generated by [Railway](https://railway.com)*