### PR TITLE
Restore Bearer token auth to fix cross-domain cookie blocking on mobi…

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -111,7 +111,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         headers: withAuthHeaders(),
       });
       if (res.status === 401 || res.status === 403) {
-        setSessionToken();
+        setSessionToken(null);
         setState((prev) =>
           prev.userId === null && prev.name === null && prev.email === null && prev.emailVerified === false
             ? prev
@@ -166,7 +166,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const login = async (email: string, password: string) => {
     const data = await callAuth<AuthUserPayload>("/login", { email, password });
-    setSessionToken();
+    setSessionToken(data.access_token ?? null);
     setState({
       userId: data.user_id,
       name: data.name,
@@ -221,7 +221,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       await callAuth<{ message: string }>("/logout", {});
     } finally {
-      setSessionToken();
+      setSessionToken(null);
       setState(EMPTY_AUTH_STATE);
     }
   };

--- a/frontend/src/lib/sessionToken.ts
+++ b/frontend/src/lib/sessionToken.ts
@@ -1,16 +1,40 @@
-const LEGACY_ACCESS_TOKEN_KEYS = ["bev_access_token", "scanscore_access_token"];
+const ACCESS_TOKEN_KEY = "bev_access_token";
+const LEGACY_ACCESS_TOKEN_KEYS = ["scanscore_access_token"];
 
-export function setSessionToken(): void {
-  if (typeof window === "undefined") return;
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
   try {
-    for (const key of LEGACY_ACCESS_TOKEN_KEYS) {
-      window.localStorage.removeItem(key);
-    }
+    return window.localStorage;
   } catch {
-    // Storage can be unavailable in hardened browser contexts.
+    return null;
   }
 }
 
+export function getSessionToken(): string | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  const token = storage.getItem(ACCESS_TOKEN_KEY)?.trim() ?? "";
+  return token || null;
+}
+
+export function setSessionToken(token: string | null): void {
+  const storage = getStorage();
+  if (!storage) return;
+  for (const key of LEGACY_ACCESS_TOKEN_KEYS) {
+    storage.removeItem(key);
+  }
+  if (!token) {
+    storage.removeItem(ACCESS_TOKEN_KEY);
+    return;
+  }
+  storage.setItem(ACCESS_TOKEN_KEY, token);
+}
+
 export function withAuthHeaders(init: HeadersInit = {}): Headers {
-  return new Headers(init);
+  const headers = new Headers(init);
+  const token = getSessionToken();
+  if (token && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  return headers;
 }


### PR DESCRIPTION
…le/Safari

Cookies alone fail when the API and frontend are on different domains — Safari blocks third-party cookies even with SameSite=None. Re-adds localStorage Bearer token (matching pre-audit behavior): login stores the JWT, withAuthHeaders injects it on every request, logout/401 clears it.